### PR TITLE
Fix parameter access.

### DIFF
--- a/IntrOS/port/STM8/SDCC/oscore.c
+++ b/IntrOS/port/STM8/SDCC/oscore.c
@@ -49,6 +49,7 @@ void _set_CC(char cc) __naked
 	
 	__asm
 
+	ld     a, (3, sp)
 	push   a
 	pop    cc
 	ret


### PR DESCRIPTION
SDCC currently passes all parameters on the stack.

Philipp
